### PR TITLE
Fix Flare gateway timeouts and three layers of error masking

### DIFF
--- a/phlare/flareClient.go
+++ b/phlare/flareClient.go
@@ -346,6 +346,15 @@ flarePaginate:
 			continue
 		}
 
+		// 502/503/504 are Flare's gateway giving up on a slow backend query
+		// (gateway timeout ≈ 30s). Usually transient when Flare's under
+		// load; retrying after a short pause typically succeeds. Bounded
+		// only by the outer client timeout (default 10 minutes).
+		if statusCode == 502 || statusCode == 503 || statusCode == 504 {
+			time.Sleep(15 * time.Second)
+			continue
+		}
+
 		if statusCode != 200 {
 			return nil, fmt.Errorf("error retrieving flare leak db results, received non 200 HTTP response status code: %d", statusCode)
 		}
@@ -504,6 +513,15 @@ flarePaginate:
 			continue
 		}
 
+		// 502/503/504 are Flare's gateway giving up on a slow backend query
+		// (gateway timeout ≈ 30s). Usually transient when Flare's under
+		// load; retrying after a short pause typically succeeds. Bounded
+		// only by the outer client timeout (default 10 minutes).
+		if statusCode == 502 || statusCode == 503 || statusCode == 504 {
+			time.Sleep(15 * time.Second)
+			continue
+		}
+
 		if statusCode != 200 {
 			return nil, fmt.Errorf("error retrieving flare leak db results, received non 200 HTTP response status code: %d", statusCode)
 		}
@@ -541,7 +559,12 @@ func (fc *FlareClient) FlareSearchCredentialsByDomainASTP(domain string) (*Flare
 	flareLeaksByDomainURL := fmt.Sprintf("%s/astp/v2/credentials/_search", flareAPIBaseURL)
 	headers := fc.defaultHeaders()
 	allData := &FlareSearchCredentialsASTP{}
-	size := "10000"
+	// Flare's gateway times out at ~30s; latency on this endpoint scales
+	// roughly linearly with page size. Empirically (worst-case slow day):
+	//   size=100 → ~8s    size=200 → ~13s    size=300 → ~24s    size=500 → 504
+	// 100 leaves >20s of headroom even on slow days; pagination handles
+	// arbitrarily-large result sets via the existing Next cursor loop.
+	size := "100"
 	postBody := &FlareSearchCredentialsBodyParams{
 		Size: size,
 		Query: FlareDomainQuery{
@@ -565,6 +588,15 @@ flarePaginate:
 
 		if statusCode == 429 {
 			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		// 502/503/504 are Flare's gateway giving up on a slow backend query
+		// (gateway timeout ≈ 30s). Usually transient when Flare's under
+		// load; retrying after a short pause typically succeeds. Bounded
+		// only by the outer client timeout (default 10 minutes).
+		if statusCode == 502 || statusCode == 503 || statusCode == 504 {
+			time.Sleep(15 * time.Second)
 			continue
 		}
 

--- a/phlare/http.go
+++ b/phlare/http.go
@@ -65,6 +65,16 @@ func (c Client) DoReq(u, method string, target interface{}, headers map[string]s
 	}
 	defer resp.Body.Close()
 
+	// Don't attempt JSON/XML decode on error responses — the body is
+	// typically plain text (e.g. "upstream request timeout" on a 504)
+	// and the decode failure ("invalid character 'u'") otherwise masks
+	// the real HTTP status from the caller. Drain the body so the
+	// connection can be reused, and let the caller branch on statusCode.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode, nil
+	}
+
 	return resp.StatusCode, DecodeResponse(resp, target)
 }
 

--- a/utils/log.go
+++ b/utils/log.go
@@ -11,23 +11,28 @@ import (
 	"time"
 )
 
-// LogError ...
+// LogError logs `err` to stderr (via gologger) and, on a best-effort basis,
+// appends it to a dated file in the CWD. The file write is non-fatal: if
+// the open fails (e.g. read-only filesystem, common in containers), we skip
+// the file tee and still log to stderr — and crucially still return the
+// ORIGINAL `err`. Returning a filesystem error in place of the caller's
+// real error has masked production failures.
 func LogError(err error) error {
 	timestamp := time.Now().Format("01-02-2006")
 	fname := fmt.Sprintf("gophlare-error-log-%s.json", timestamp)
 
-	f, openFileErr := os.OpenFile(fname, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
-	if openFileErr != nil {
-		return openFileErr
-	}
-	defer f.Close()
-	teeFormatter := formatter.NewTee(formatter.NewCLI(false), f)
-	gologger.DefaultLogger.SetFormatter(teeFormatter)
 	pc, file, line, ok := runtime.Caller(1)
 	if !ok {
 		LogWarningf("Failed to retrieve Caller information")
 	}
 	fn := runtime.FuncForPC(pc).Name()
+
+	f, openFileErr := os.OpenFile(fname, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if openFileErr == nil {
+		defer f.Close()
+		teeFormatter := formatter.NewTee(formatter.NewCLI(false), f)
+		gologger.DefaultLogger.SetFormatter(teeFormatter)
+	}
 	gologger.DefaultLogger.SetMaxLevel(levels.LevelError)
 	gologger.Error().Msgf("Error in function %s, called from %s:%d:\n %v", fn, file, line, err)
 	return err


### PR DESCRIPTION
## Summary

Three independent bugs that combined to silently swallow Flare API failures in production deployments, surfaced by a credential-testing platform using gophlare against a customer domain with ~1k breach hits.

Three commits, one logical fix each. All upstream-worthy — no API surface changes, no caller breaks.

| # | Commit | File |
|---|---|---|
| 1 | `phlare: make credentials search resilient to Flare gateway timeouts` | `phlare/flareClient.go` |
| 2 | `utils: LogError no longer masks the caller's original error` | `utils/log.go` |
| 3 | `phlare: don't JSON-decode error response bodies in DoReq` | `phlare/http.go` |

## Bug 1 — credentials search 504s under load

`FlareSearchCredentialsByDomainASTP` hardcoded `size := "10000"`. Flare's gateway times out at ~30s and returns HTTP 504 `upstream request timeout` whenever the backend can't materialize a page within that window. The endpoint's latency scales roughly linearly with `size` — measured against a single tenant on a slow-day production trace:

| `size` | latency | result |
|---|---|---|
| 10 | 3.9s | ✓ |
| 50 | 6.3s | ✓ |
| 100 | 8.0s | ✓ |
| 200 | 13.2s | ✓ (but close on a worse network path) |
| 300 | 23.9s | ✓ (only 6s headroom) |
| 500 | 30.2s | **504** |

So `size=10000` was effectively always going to 504 on any non-trivial corpus. There was also no retry path for the resulting 5xx responses — a single transient 504 failed the entire per-domain pull.

**Fix:** lower `size` to `100` (>20s of headroom even on slow days) and add `502/503/504 → sleep+retry` alongside the existing `429` case in all three pagination loops (`credentials/_search`, `cookies/_search`, and the `astp/v2/credentials/_search` endpoint). Pagination via the existing `Next` cursor loop is unaffected, so total-result-set ceilings are unchanged.

## Bug 2 — `utils.LogError` masks the caller's original error on read-only FS

`LogError` opens a dated log file in CWD. When the open fails (CI runners, hardened containers, `os.Chroot`'d processes), it returned the filesystem error **in place of** the caller's original `err`:

```go
f, openFileErr := os.OpenFile(fname, ...)
if openFileErr != nil {
    return openFileErr   // ← masks the caller's err
}
```

Every API failure surfaced as `"open gophlare-error-log-…: read-only file system"`. The actual underlying error became unreachable from outside the SDK. In production deployments running on read-only container roots, this meant *every* gophlare failure looked identical regardless of root cause.

**Fix:** file write becomes best-effort. On open failure we skip the file tee, still log via gologger to stderr, and always return the caller's original `err`. The public contract is unchanged — `LogError` still returns an error — but it's now the real one.

## Bug 3 — `DoReq` JSON-decodes error response bodies

`DoReq` returned `(statusCode, DecodeResponse(resp, target))` regardless of HTTP status. When the API returned a non-2xx with a non-JSON body (e.g. Flare's gateway returning plain text `"upstream request timeout"` on a 504), the JSON decoder errored on the first byte with `"invalid character 'u' looking for beginning of value"`. Callers that check `err` before `statusCode` saw only the decoder failure, never the actual 504.

**Fix:** skip the decode entirely on non-2xx. Drain the body so the connection can be reused, return `(statusCode, nil)`, and let the caller's existing `if statusCode != 200` branch handle it cleanly.

## How the three combined to hide the failure

The bug report that produced this PR was: "Flare campaign ran, event log says `pulled 0 items` with no error." The actual failure chain was:

1. gophlare sent `size: "10000"` → Flare returned 504
2. `DoReq` tried to JSON-decode the 504 body → returned `"invalid character 'u'…"`
3. `LogError` wrapped that error, then failed to write the log file (read-only container FS), and returned the FS error instead
4. The downstream consumer recorded `"open gophlare-error-log-…: read-only file system"` as the failure cause — three layers removed from the real one

Each bug independently is a real defect; combined they produced a misleading error message and no obvious diagnostic path. Each fix is small and self-contained.

## Verification

- All three patches apply cleanly against `main` (verified via `git am` + `go build ./... && go vet ./...`)
- Latency / size threshold reproduced deterministically via `curl` against `api.flare.io` on the affected tenant
- Post-fix integration test: a real ingest pulling 1056 credentials across ~11 paginated pages, end-to-end, no errors
- No tests removed, no public-API surface changes
